### PR TITLE
Refine scroll area layout for scalable video preview

### DIFF
--- a/GUI/UI/UI_Main.ui
+++ b/GUI/UI/UI_Main.ui
@@ -44,52 +44,55 @@
            <bool>true</bool>
           </property>
           <widget class="QWidget" name="scrollAreaWidgetContents">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>1600</width>
-             <height>850</height>
-            </rect>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>1600</width>
-             <height>850</height>
-            </size>
-           </property>
-           <widget class="QLabel" name="label_3">
-            <property name="geometry">
-             <rect>
-              <x>9</x>
-              <y>9</y>
-              <width>2000</width>
-              <height>1000</height>
-             </rect>
+           <layout class="QStackedLayout" name="stackedLayout">
+            <property name="contentsMargins">
+             <left>0</left>
+             <top>0</top>
+             <right>0</right>
+             <bottom>0</bottom>
             </property>
-            <property name="styleSheet">
-             <string notr="true">background: gray;</string>
+            <property name="stackingMode">
+             <enum>QStackedLayout::StackAll</enum>
             </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-           <widget class="QLabel" name="label_4">
-            <property name="geometry">
-             <rect>
-              <x>10</x>
-              <y>10</y>
-              <width>2000</width>
-              <height>1000</height>
-             </rect>
-            </property>
-            <property name="mouseTracking">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background: gray;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="mouseTracking">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </widget>
          <widget class="QWidget" name="layoutWidget">

--- a/GUI/UI_Main.py
+++ b/GUI/UI_Main.py
@@ -71,30 +71,32 @@ class Ui_MainWindow(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollArea.setObjectName("scrollArea")
         self.scrollAreaWidgetContents = QtWidgets.QWidget()
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 1298, 848))
-        self.scrollAreaWidgetContents.setMinimumSize(QtCore.QSize(1300, 850))
         self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
+        self.stackedLayout = QtWidgets.QStackedLayout(self.scrollAreaWidgetContents)
+        self.stackedLayout.setContentsMargins(0, 0, 0, 0)
+        self.stackedLayout.setStackingMode(QtWidgets.QStackedLayout.StackAll)
         self.label_3 = QtWidgets.QLabel(self.scrollAreaWidgetContents)
-        self.label_3.setGeometry(QtCore.QRect(9, 9, 2000, 1000))
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.label_3.setSizePolicy(sizePolicy)
         self.label_3.setStyleSheet("background: gray;")
+        self.label_3.setScaledContents(True)
         self.label_3.setText("")
         self.label_3.setObjectName("label_3")
+        self.stackedLayout.addWidget(self.label_3)
 
         self.videoWidget = QVideoWidget(self.label_3)
 
         self.mediaPlayer = QMediaPlayer()
         self.mediaPlayer.setVideoOutput(self.videoWidget)
-        
+
         self.label_4 = QtWidgets.QLabel(self.scrollAreaWidgetContents)
-        self.label_4.setGeometry(QtCore.QRect(10, 10, 2000, 1000))
+        self.label_4.setSizePolicy(sizePolicy)
         self.label_4.setMouseTracking(True)
+        self.label_4.setScaledContents(True)
         self.label_4.setText("")
         self.label_4.setObjectName("label_4")
-
-        # 如果 scrollAreaWidgetContents 没有布局，给它设置一个默认布局
-        if not self.scrollAreaWidgetContents.layout():
-            self.layout = QtWidgets.QVBoxLayout(self.scrollAreaWidgetContents)
-            self.scrollAreaWidgetContents.setLayout(self.layout)
+        self.label_4.setStyleSheet("background: transparent;")
+        self.stackedLayout.addWidget(self.label_4)
 
         self.scrollArea.setWidget(self.scrollAreaWidgetContents)
         self.layoutWidget = QtWidgets.QWidget(self.splitter)
@@ -280,25 +282,37 @@ class Ui_MainWindow(object):
 
     def enableLabel4(self):
         # 点击打开目录后启用 MyLabel
-        self.label_4.deleteLater()  # 删除原来的 QLabel
-        
+        if self.label_4:
+            self.stackedLayout.removeWidget(self.label_4)
+            self.label_4.deleteLater()  # 删除原来的 QLabel
+
         # 创建 MyLabel 实例并添加到布局
         self.label_4 = MyLabel(self.scrollAreaWidgetContents)
-        self.label_4.setGeometry(QtCore.QRect(10, 10, 2000, 1000))
-        self.label_4.setText("")
         self.label_4.setObjectName("label_4")
-        self.scrollAreaWidgetContents.layout().addWidget(self.label_4)
-        
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.label_4.setSizePolicy(sizePolicy)
+        self.label_4.setMouseTracking(True)
+        self.label_4.setScaledContents(True)
+        self.label_4.setStyleSheet("background: transparent;")
+        self.label_4.setText("")
+        self.stackedLayout.addWidget(self.label_4)
+
 
 
     def disableLabel4(self):
-        self.label_4.deleteLater()  # 删除原来的 QLabel
-        
+        if self.label_4:
+            self.stackedLayout.removeWidget(self.label_4)
+            self.label_4.deleteLater()  # 删除原来的 QLabel
+
         self.label_4 = QtWidgets.QLabel(self.scrollAreaWidgetContents)
-        self.label_4.setGeometry(QtCore.QRect(10, 10, 2000, 1000))
-        self.label_4.setText("")
         self.label_4.setObjectName("label_4")
-        self.scrollAreaWidgetContents.layout().addWidget(self.label_4)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.label_4.setSizePolicy(sizePolicy)
+        self.label_4.setMouseTracking(True)
+        self.label_4.setScaledContents(True)
+        self.label_4.setStyleSheet("background: transparent;")
+        self.label_4.setText("")
+        self.stackedLayout.addWidget(self.label_4)
         
 
 


### PR DESCRIPTION
## Summary
- replace fixed geometries in the scroll area with a stacked layout so the video and annotation layers scale with the window
- configure the stacked labels with expanding size policies, zero margins, and transparent overlay handling to maintain interactions
- update helper methods to rebuild the overlay label using the shared layout when toggling annotation modes

## Testing
- python -m compileall GUI/UI_Main.py

------
https://chatgpt.com/codex/tasks/task_e_68da0d332960832993064de6fd26b573