### PR TITLE
Ensure overlay label stays on top of stacked layout

### DIFF
--- a/GUI/UI_Main.py
+++ b/GUI/UI_Main.py
@@ -97,6 +97,7 @@ class Ui_MainWindow(object):
         self.label_4.setObjectName("label_4")
         self.label_4.setStyleSheet("background: transparent;")
         self.stackedLayout.addWidget(self.label_4)
+        self.stackedLayout.setCurrentWidget(self.label_4)
 
         self.scrollArea.setWidget(self.scrollAreaWidgetContents)
         self.layoutWidget = QtWidgets.QWidget(self.splitter)
@@ -296,6 +297,7 @@ class Ui_MainWindow(object):
         self.label_4.setStyleSheet("background: transparent;")
         self.label_4.setText("")
         self.stackedLayout.addWidget(self.label_4)
+        self.stackedLayout.setCurrentWidget(self.label_4)
 
 
 
@@ -313,6 +315,7 @@ class Ui_MainWindow(object):
         self.label_4.setStyleSheet("background: transparent;")
         self.label_4.setText("")
         self.stackedLayout.addWidget(self.label_4)
+        self.stackedLayout.setCurrentWidget(self.label_4)
         
 
 


### PR DESCRIPTION
## Summary
- ensure the overlay label is promoted to the top of the stacked layout whenever it is added so drawing events remain active

## Testing
- python Run.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68da17a7369083298a8c827b1f9f7d03