### PR TITLE
Add PyInstaller packaging spec and resource helpers

### DIFF
--- a/GUI/UI_Main.py
+++ b/GUI/UI_Main.py
@@ -12,6 +12,8 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtMultimediaWidgets import QVideoWidget
 from PyQt5.QtMultimedia import QMediaPlayer, QMediaContent
 
+from util.path_utils import resource_path
+
 
 # 鼠标绘画事件
 class MyLabel(QtWidgets.QLabel):
@@ -52,7 +54,7 @@ class Ui_MainWindow(object):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(1618, 947)
         icon = QtGui.QIcon()
-        icon.addPixmap(QtGui.QPixmap("GUI/icons/logo.ico"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/logo.ico")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         MainWindow.setWindowIcon(icon)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
@@ -204,7 +206,7 @@ class Ui_MainWindow(object):
         MainWindow.setStatusBar(self.statusbar)
         self.actionOpen_Dir = QtWidgets.QAction(MainWindow)
         icon1 = QtGui.QIcon()
-        icon1.addPixmap(QtGui.QPixmap("GUI/icons/open.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon1.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/open.png")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionOpen_Dir.setIcon(icon1)
         self.actionOpen_Dir.setObjectName("actionOpen_Dir")
 
@@ -212,38 +214,38 @@ class Ui_MainWindow(object):
 
         self.actionChange_Save_Dir = QtWidgets.QAction(MainWindow)
         icon2 = QtGui.QIcon()
-        icon2.addPixmap(QtGui.QPixmap("GUI/icons/save.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon2.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/save.png")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionChange_Save_Dir.setIcon(icon2)
         self.actionChange_Save_Dir.setObjectName("actionChange_Save_Dir")
         self.actionNext_Image = QtWidgets.QAction(MainWindow)
         self.actionNext_Image.setEnabled(False)
         icon3 = QtGui.QIcon()
-        icon3.addPixmap(QtGui.QPixmap("GUI/icons/next.jpg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon3.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/next.jpg")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionNext_Image.setIcon(icon3)
         self.actionNext_Image.setObjectName("actionNext_Image")
         self.actionPrev_Image = QtWidgets.QAction(MainWindow)
         self.actionPrev_Image.setEnabled(False)
         self.actionVideo_marking = QtWidgets.QAction(MainWindow)
         icon7 = QtGui.QIcon()
-        icon7.addPixmap(QtGui.QPixmap("GUI/icons/Video_marking.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon7.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/Video_marking.png")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionVideo_marking.setIcon(icon7)
         self.actionVideo_marking.setObjectName("actionVideo_marking")
 
         self.actionVideo_marking.triggered.connect(self.enableLabel4)
 
         icon4 = QtGui.QIcon()
-        icon4.addPixmap(QtGui.QPixmap("GUI/icons/prev.jpg"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon4.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/prev.jpg")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionPrev_Image.setIcon(icon4)
         self.actionPrev_Image.setObjectName("actionPrev_Image")
         self.actionCreate_RectBox = QtWidgets.QAction(MainWindow)
         self.actionCreate_RectBox.setEnabled(False)
         icon5 = QtGui.QIcon()
-        icon5.addPixmap(QtGui.QPixmap("GUI/icons/create.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon5.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/create.png")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionCreate_RectBox.setIcon(icon5)
         self.actionCreate_RectBox.setObjectName("actionCreate_RectBox")
         self.actionOpen_Video = QtWidgets.QAction(MainWindow)
         icon6 = QtGui.QIcon()
-        icon6.addPixmap(QtGui.QPixmap("GUI/icons/video.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
+        icon6.addPixmap(QtGui.QPixmap(resource_path("GUI/icons/video.png")), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionOpen_Video.setIcon(icon6)
         self.actionOpen_Video.setObjectName("actionOpen_Video")
 

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -10,11 +10,17 @@ import cv2
 import numpy as np
 from util.QtFunc import *
 from util.xmlfile import *
+from util.path_utils import resource_path
 
 from GUI.UI_Main import Ui_MainWindow
 from GUI.message import LabelInputDialog
 
-sys.path.append("smapro")
+SAMPRO_PATH = Path(resource_path("sampro"))
+if SAMPRO_PATH.exists():
+    sampro_str = str(SAMPRO_PATH)
+    if sampro_str not in sys.path:
+        sys.path.append(sampro_str)
+
 from sampro.LabelQuick_TW import Anything_TW
 from sampro.LabelVideo_TW import AnythingVideo_TW
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,33 @@
+# Packaging Auto Yolo Labeler
+
+This directory stores helper assets for building a standalone Windows
+executable with [PyInstaller](https://pyinstaller.org/).
+
+## Prerequisites
+
+1. Install the Python dependencies listed in `requirements.txt`. The list
+   already contains the runtime stack required by the application when frozen
+   (PyQt5, OpenCV, Torch, etc.) as well as `pyinstaller>=6.10.0` for the
+   packaging step.
+2. Download the Segment Anything v2 (SAM2) model weights and place them in
+   `sampro/checkpoints/`. The application expects the file
+   `sam2.1_hiera_large.pt` by default; override the `SAM2_CHECKPOINT`
+   environment variable if you use another filename.
+
+## Build
+
+From the project root:
+
+```bash
+pyinstaller packaging/auto_yolo_labeler.spec
+```
+
+The spec file bundles the GUI icons together with the `segment`, `util`, and
+`sampro` packages so that model weights and helper modules remain available at
+runtime. The resulting executable is written to `dist/AutoYoloLabeler.exe`.
+
+## Testing
+
+After building, copy the `dist` folder to a clean Windows machine and launch
+`AutoYoloLabeler.exe` to verify that the GUI opens and the automatic labelling
+pipeline runs end-to-end with your SAM model checkpoint.

--- a/packaging/auto_yolo_labeler.spec
+++ b/packaging/auto_yolo_labeler.spec
@@ -1,0 +1,103 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+block_cipher = None
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RESOURCE_DIRS = [
+    "GUI/icons",
+    "segment",
+    "util",
+    "sampro",
+]
+
+
+def _collect_resource_tree():
+    datas = []
+    for relative in RESOURCE_DIRS:
+        source_root = PROJECT_ROOT / relative
+        if not source_root.exists():
+            continue
+        for path in source_root.rglob("*"):
+            if path.is_file():
+                target = Path(relative) / path.relative_to(source_root)
+                datas.append((str(path), str(target)))
+    return datas
+
+
+def _collect_hiddenimports():
+    try:
+        from PyInstaller.utils.hooks import collect_submodules  # type: ignore
+    except Exception:  # pragma: no cover - PyInstaller is only available during packaging
+        return []
+
+    hidden = []
+    for package in ("sampro", "segment"):
+        try:
+            hidden.extend(collect_submodules(package))
+        except Exception:
+            continue
+    # Preserve ordering but drop duplicates
+    seen = set()
+    result = []
+    for name in hidden:
+        if name in seen:
+            continue
+        seen.add(name)
+        result.append(name)
+    return result
+
+
+datas = _collect_resource_tree()
+hiddenimports = _collect_hiddenimports()
+
+pathex = [str(PROJECT_ROOT)]
+
+
+a = Analysis(
+    [str(PROJECT_ROOT / "Run.py")],
+    pathex=pathex,
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="AutoYoloLabeler",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=str(PROJECT_ROOT / "GUI/icons/logo.ico"),
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="AutoYoloLabeler",
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ cython==3.0.11
 # Packaging helpers
 setuptools>=68.0.0
 wheel>=0.44.0
+pyinstaller>=6.10.0

--- a/util/path_utils.py
+++ b/util/path_utils.py
@@ -1,0 +1,34 @@
+"""Utilities for resolving resource paths in both source and frozen builds."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Union
+
+
+def get_base_path() -> Path:
+    """Return the base directory that holds bundled resources."""
+    if hasattr(sys, "_MEIPASS"):
+        meipass = getattr(sys, "_MEIPASS")
+        if meipass:
+            return Path(meipass)
+    return Path(__file__).resolve().parents[1]
+
+
+def resource_path(relative_path: Union[str, os.PathLike[str]]) -> str:
+    """Resolve *relative_path* against the application resource root.
+
+    When the app is frozen by PyInstaller, resources are extracted beneath
+    ``sys._MEIPASS``. During local development we fall back to the project
+    root, allowing the same call sites to load icons, configuration files,
+    or model checkpoints regardless of execution environment.
+    """
+
+    path = Path(relative_path)
+    if path.is_absolute():
+        return str(path)
+
+    base = get_base_path()
+    return str((base / path).resolve())


### PR DESCRIPTION
## Summary
- add a PyInstaller spec that bundles GUI icons, sampro, segment, and util resources
- provide a shared resource_path helper and update the Qt GUI to load icons from bundled locations
- document the packaging workflow and include PyInstaller in the requirements list

## Testing
- python -m compileall GUI/main.py GUI/UI_Main.py util/path_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68da1ef46a688329808d6885dacf2142