### PR TITLE
Add progress reporting to video labeling workflow

### DIFF
--- a/GUI/main.py
+++ b/GUI/main.py
@@ -23,6 +23,7 @@ from PyQt5.QtCore import QThread, pyqtSignal, QTimer
 class VideoProcessingThread(QThread):
     finished = pyqtSignal()  # 完成信号
     frame_ready = pyqtSignal(object)  # 添加新信号用于传递处理后的帧
+    progress_changed = pyqtSignal(int, int)  # 当前帧，总帧数
 
     def __init__(self, avt, video_path, output_dir, prompts, label_map, save_path):
         super().__init__()
@@ -34,6 +35,7 @@ class VideoProcessingThread(QThread):
         self.save_path = save_path
         self.xml_messages = []
         os.makedirs(self.output_dir, exist_ok=True)
+        self.total_frames = 0
 
     def run(self):
         try:
@@ -43,7 +45,10 @@ class VideoProcessingThread(QThread):
             os.makedirs(mask_dir, exist_ok=True)
 
             # 提取视频帧
-            self.AVT.extract_frames_from_video(self.video_path, self.output_dir,fps=2)
+            _, saved_count = self.AVT.extract_frames_from_video(self.video_path, self.output_dir, fps=2)
+            self.total_frames = saved_count
+            self.progress_changed.emit(0, self.total_frames)
+
             self.AVT.set_video(self.output_dir)
             self.AVT.inference(self.output_dir)
             self.AVT.reset_object_prompts()
@@ -65,10 +70,15 @@ class VideoProcessingThread(QThread):
                 self.AVT.add_new_points_or_box(obj_id=obj_id)
 
             # 获取处理后的帧并发送信号
+            def progress_callback(frame_idx, total_frames):
+                total = self.total_frames or total_frames or 0
+                self.progress_changed.emit(frame_idx + 1, total)
+
             processed_frame, xml_messages = self.AVT.Draw_Mask_at_frame(
                 save_image_path=mask_dir,
                 save_path=self.save_path,
                 label_map=self.label_map,
+                progress_callback=progress_callback,
             )  # 使用新的mask_dir路径
             self.xml_messages = xml_messages
             self.frame_ready.emit(processed_frame)  # 发送处理后的帧
@@ -948,6 +958,9 @@ class MainFunc(QMainWindow):
 
 
     def on_video_processing_complete(self):
+        self.ui.progressBar.hide()
+        self.ui.progressBar.setValue(0)
+        self.ui.progressBar.setRange(0, 100)
         self.worker_thread.deleteLater()
         self.xml_messages = self.worker_thread.xml_messages
         # print(self.xml_messages)
@@ -982,6 +995,16 @@ class MainFunc(QMainWindow):
         self.ui.listWidget.addItem("检测打标完成！")
         print("检测打标完成！")
         self.ui.pushButton_start_marking.setEnabled(bool(self.video_prompt_queue))
+
+    def on_video_progress_changed(self, current, total):
+        if total and self.ui.progressBar.maximum() != total:
+            self.ui.progressBar.setRange(0, total)
+
+        # 防止 current 超出范围
+        if total and current > total:
+            current = total
+
+        self.ui.progressBar.setValue(current)
 
     def on_save_type_triggered(self, fmt, checked):
         if checked:
@@ -1057,7 +1080,18 @@ class MainFunc(QMainWindow):
                 label_map,
                 self.save_path,
             )
-            self.worker_thread.finished.connect(self.on_video_processing_complete)
+            self.worker_thread.progress_changed.connect(
+                self.on_video_progress_changed,
+                Qt.QueuedConnection,
+            )
+            self.worker_thread.finished.connect(
+                self.on_video_processing_complete,
+                Qt.QueuedConnection,
+            )
+
+            self.ui.progressBar.show()
+            self.ui.progressBar.setValue(0)
+            self.ui.progressBar.setRange(0, 0)
             self.worker_thread.start()
 
         else:

--- a/sampro/LabelVideo_TW.py
+++ b/sampro/LabelVideo_TW.py
@@ -374,6 +374,7 @@ class AnythingVideo_TW():
         save_image_path=None,
         save_path=None,
         label_map=None,
+        progress_callback=None,
     ):
         """
         遍历所有帧并绘制轮廓
@@ -407,7 +408,9 @@ class AnythingVideo_TW():
 
         # 遍历所有帧
         xml_messages = []
-        for frame_idx in range(start_frame, len(frame_names)):
+        total_frames = len(frame_names)
+
+        for frame_idx in range(start_frame, total_frames):
             frame_path = os.path.join(self.video_path, frame_names[frame_idx])
             frame = cv2.imread(frame_path)
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
@@ -477,6 +480,12 @@ class AnythingVideo_TW():
                                 xml_messages.append([out_obj_id, result_label, file_path, size])
             else:
                 print(f"Warning: Invalid frame at index {frame_idx}")
+
+            if progress_callback:
+                try:
+                    progress_callback(frame_idx, total_frames)
+                except Exception as callback_error:
+                    print(f"Progress callback error at frame {frame_idx}: {callback_error}")
 
         # 始终返回元组，而不是在 return_frames=False 时返回 None
         return processed_frames, xml_messages


### PR DESCRIPTION
## Summary
- add a progress_changed signal to the video processing thread and emit updates while frames are processed
- wire the UI progress bar to the new signal and reset the indicator when processing finishes
- allow Draw_Mask_at_frame to receive a progress callback invoked for each processed frame

## Testing
- python -m compileall GUI/main.py sampro/LabelVideo_TW.py

------
https://chatgpt.com/codex/tasks/task_e_68da1ef471748329a45407891b51c0e5